### PR TITLE
feat(clojure): add levenshtein implementation

### DIFF
--- a/.github/workflows/pr_clojure.yml
+++ b/.github/workflows/pr_clojure.yml
@@ -22,7 +22,7 @@ jobs:
         run: lein deps
         working-directory: ${{ env.working-directory }}
       - name: Run tests
-        run: lein cloverage --codecov
+        run: lein coverage
         working-directory: ${{ env.working-directory }}
       - name: Report coverage
         uses: codecov/codecov-action@v2

--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -1,9 +1,11 @@
 (defproject com.teknologiumum/pehape-clj "0.0.1"
   :description "PHP stdlib global functions implemented in Clojure"
   :url "https://github.com/teknologi-umum/pehape"
-  :plugins [[lein-cloverage "1.2.2"]]
   :dependencies [[org.clojure/clojure "1.10.3"]]
-  :profiles {:dev {:dependencies [[cider/cider-nrepl "0.28.3"]]}}
+  :profiles {:dev {:dependencies [[cider/cider-nrepl "0.28.3"]]}
+             :test {:plugins [[lein-cloverage "1.2.2"]]
+                    :cloverage {:exclude-call [clojure.core/doseq]}}}
+  :aliases {"coverage" ["with-profile" "test" "cloverage" "--codecov"]}
   :target-path "target/%s"
   :main pehape.core
   :aot [pehape.core])

--- a/clojure/src/pehape/string.clj
+++ b/clojure/src/pehape/string.clj
@@ -61,40 +61,7 @@
    - IllegalArgumentException when `insert-cost`, `replace-cost`, or `delete-cost` is negative"
   {:added "0.0.1"}
   ([str1 str2]
-   (cond
-     (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))
-     (nil? str2) (throw (IllegalArgumentException. "str2 cannot be nil"))
-     (zero? (count str1)) (count str2)
-     (zero? (count str2)) (count str1)
-     :else
-     (let [p1 (atom (into [] (range (+ 1 (count str2)))))
-           p2 (atom [])
-           swapped (atom false)]
-       (doseq [i1 (range (count str1))]
-         (if @swapped
-           (swap! p1 #(assoc % 0 (+ 1 (first @p2))))
-           (swap! p2 #(assoc % 0 (+ 1 (first @p1)))))
-         (doseq [i2 (range (count str2))]
-           (let [c0 (atom (+ (if @swapped
-                               (nth @p2 i2)
-                               (nth @p1 i2))
-                             (if (= (nth str1 i1)
-                                    (nth str2 i2)) 0 1)))
-                 c1 (atom (+ 1 (if @swapped
-                                 (nth @p2 (+ 1 i2))
-                                 (nth @p1 (+ 1 i2)))))
-                 c2 (atom (+ 1 (if @swapped
-                                 (nth @p1 i2)
-                                 (nth @p2 i2))))]
-             (when (< @c1 @c0) (swap! c0 (fn [_] @c1)))
-             (when (< @c2 @c0) (swap! c0 (fn [_] @c2)))
-             (if @swapped
-               (swap! p1 (fn [n] (assoc n (+ 1 i2) @c0)))
-               (swap! p2 (fn [n] (assoc n (+ 1 i2) @c0))))))
-         (swap! swapped (fn [n] (not n))))
-       (if @swapped
-         (nth @p2 (count str2))
-         (nth @p1 (count str2))))))
+   (levenshtein str1 str2 1 1 1))
   ([str1 str2 insert-cost replace-cost delete-cost]
    (cond
      (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))

--- a/clojure/src/pehape/string.clj
+++ b/clojure/src/pehape/string.clj
@@ -43,3 +43,97 @@
   {:added "0.0.1"}
   [separator array]
   (str/join separator array))
+
+
+(defn levenshtein
+  "The Levenshtein function returns the Levenshtein distance between two strings.
+   
+   Arguments:
+   - `str1` First string to compare.
+   - `str2` Second string to compare.
+   - `insert-cost` The cost of inserting a character.
+   - `replace-cost` The cost of replacing a character.
+   - `delete-cost` The cost of deleting a character.
+   Returns:
+   - The Levenshtein distance between two argument strings.
+   Exceptions:
+   - IllegalArgumentException when `str1` or `str2` is null.
+   - IllegalArgumentException when `insert-cost`, `replace-cost`, or `delete-cost` is negative"
+  {:added "0.0.1"}
+  ([str1 str2]
+   (cond
+     (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))
+     (nil? str2) (throw (IllegalArgumentException. "str2 cannot be nil"))
+     (= (count str1) 0) (count str2)
+     (= (count str2) 0) (count str1)
+     :else
+     (let [p1 (atom (into [] (range (+ 1 (count str2)))))
+           p2 (atom [])
+           swapped (atom false)]
+       (doseq [i1 (range (count str1))]
+         (if @swapped
+           (swap! p1 #(assoc % 0 (+ 1 (first @p2))))
+           (swap! p2 #(assoc % 0 (+ 1 (first @p1)))))
+         (doseq [i2 (range (count str2))]
+           (let [c0 (atom (+ (if @swapped
+                               (nth @p2 i2)
+                               (nth @p1 i2))
+                             (if (= (nth str1 i1)
+                                    (nth str2 i2)) 0 1)))
+                 c1 (atom (+ 1 (if @swapped
+                                 (nth @p2 (+ 1 i2))
+                                 (nth @p1 (+ 1 i2)))))
+                 c2 (atom (+ 1 (if @swapped
+                                 (nth @p1 i2)
+                                 (nth @p2 i2))))]
+             (when (< @c1 @c0) (swap! c0 (fn [_] @c1)))
+             (when (< @c2 @c0) (swap! c0 (fn [_] @c2)))
+             (if @swapped
+               (swap! p1 (fn [n] (assoc n (+ 1 i2) @c0)))
+               (swap! p2 (fn [n] (assoc n (+ 1 i2) @c0))))))
+         (swap! swapped (fn [n] (not n))))
+       (if @swapped
+         (nth @p2 (count str2))
+         (nth @p1 (count str2))))))
+  ([str1 str2 insert-cost replace-cost delete-cost]
+   (cond
+     (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))
+     (nil? str2) (throw (IllegalArgumentException. "str2 cannot be nil"))
+     (< insert-cost 0) (throw (IllegalArgumentException. "insert-cost cannot be a negative value"))
+     (< replace-cost 0) (throw (IllegalArgumentException. "replace-cost cannot be a negative value"))
+     (< delete-cost 0) (throw (IllegalArgumentException. "delete-cost cannot be a negative value"))
+     (= (count str1) 0) (* insert-cost (count str2))
+     (= (count str2) 0) (* delete-cost (count str1))
+     :else
+     (let [p1 (atom (into [] (map #(* insert-cost %)
+                                  (range (+ 1 (count str2))))))
+           p2 (atom [])
+           swapped (atom false)]
+       (doseq [i1 (range (count str1))]
+         (if @swapped
+           (swap! p1 #(assoc % 0 (+ delete-cost (first @p2))))
+           (swap! p2 #(assoc % 0 (+ delete-cost (first @p1)))))
+         (doseq [i2 (range (count str2))]
+           (let [c0 (atom (+ (if @swapped
+                               (nth @p2 i2)
+                               (nth @p1 i2))
+                             (if (= (nth str1 i1) (nth str2 i2))
+                               0
+                               replace-cost)))
+                 c1 (atom (+ delete-cost
+                             (if @swapped
+                               (nth @p2 (+ 1 i2))
+                               (nth @p1 (+ 1 i2)))))
+                 c2 (atom (+ insert-cost
+                             (if @swapped
+                               (nth @p1 i2)
+                               (nth @p2 i2))))]
+             (when (< @c1 @c0) (swap! c0 (fn [_] @c1)))
+             (when (< @c2 @c0) (swap! c0 (fn [_] @c2)))
+             (if @swapped
+               (swap! p1 (fn [n] (assoc n (+ 1 i2) @c0)))
+               (swap! p2 (fn [n] (assoc n (+ 1 i2) @c0))))))
+         (swap! swapped (fn [n] (not n))))
+       (if @swapped
+         (nth @p2 (count str2))
+         (nth @p1 (count str2)))))))

--- a/clojure/src/pehape/string.clj
+++ b/clojure/src/pehape/string.clj
@@ -64,8 +64,8 @@
    (cond
      (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))
      (nil? str2) (throw (IllegalArgumentException. "str2 cannot be nil"))
-     (= (count str1) 0) (count str2)
-     (= (count str2) 0) (count str1)
+     (zero? (count str1)) (count str2)
+     (zero? (count str2)) (count str1)
      :else
      (let [p1 (atom (into [] (range (+ 1 (count str2)))))
            p2 (atom [])
@@ -99,11 +99,11 @@
    (cond
      (nil? str1) (throw (IllegalArgumentException. "str1 cannot be nil"))
      (nil? str2) (throw (IllegalArgumentException. "str2 cannot be nil"))
-     (< insert-cost 0) (throw (IllegalArgumentException. "insert-cost cannot be a negative value"))
-     (< replace-cost 0) (throw (IllegalArgumentException. "replace-cost cannot be a negative value"))
-     (< delete-cost 0) (throw (IllegalArgumentException. "delete-cost cannot be a negative value"))
-     (= (count str1) 0) (* insert-cost (count str2))
-     (= (count str2) 0) (* delete-cost (count str1))
+     (neg? insert-cost) (throw (IllegalArgumentException. "insert-cost cannot be a negative value"))
+     (neg? replace-cost) (throw (IllegalArgumentException. "replace-cost cannot be a negative value"))
+     (neg? delete-cost) (throw (IllegalArgumentException. "delete-cost cannot be a negative value"))
+     (zero? (count str1)) (* insert-cost (count str2))
+     (zero? (count str2)) (* delete-cost (count str1))
      :else
      (let [p1 (atom (into [] (map #(* insert-cost %)
                                   (range (+ 1 (count str2))))))

--- a/clojure/test/pehape/string_test.clj
+++ b/clojure/test/pehape/string_test.clj
@@ -1,6 +1,6 @@
 (ns pehape.string-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [pehape.string :refer [explode implode]]))
+  (:require [clojure.test :refer [deftest is testing are]]
+            [pehape.string :refer [explode implode levenshtein]]))
 
 
 (deftest explode-test
@@ -51,3 +51,73 @@
     #_{:clj-kondo/ignore [:inline-def]}
     (def array [])
     (is (= (implode " " array) ""))))
+
+
+(deftest levenshtein-test
+  (testing "Throws an error when str1 or str2 is nil"
+    (is (thrown-with-msg? IllegalArgumentException #"str1 cannot be nil"
+                          (levenshtein nil "")))
+    (is (thrown-with-msg? IllegalArgumentException #"str1 cannot be nil"
+                          (levenshtein nil "" 1 1 1)))
+    (is (thrown-with-msg? IllegalArgumentException #"str2 cannot be nil"
+                          (levenshtein "" nil)))
+    (is (thrown-with-msg? IllegalArgumentException #"str2 cannot be nil"
+                          (levenshtein "" nil 1 1 1))))
+  (testing "Throws an error when cost is negative"
+    (is (thrown-with-msg? IllegalArgumentException #"insert-cost cannot be a negative value"
+                          (levenshtein "a" "a" -1 1 1)))
+    (is (thrown-with-msg? IllegalArgumentException #"replace-cost cannot be a negative value"
+                          (levenshtein "a" "a" 1 -1 1)))
+    (is (thrown-with-msg? IllegalArgumentException #"delete-cost cannot be a negative value"
+                          (levenshtein "a" "a" 1 1 -1))))
+  (testing "Returns Correct Distance"
+    (testing "Custom Test Cases"
+      ;; equal
+      (is (= 0 (levenshtein "12345" "12345")))
+      ;; first string empty
+      (is (= 3 (levenshtein "" "xyz")))
+      ;; second string empty
+      (is (= 3 (levenshtein "xyz" "")))
+      (is (= 3 (levenshtein "xyz" "" 1 1 1)))
+      ;; both empty
+      (is (= 0 (levenshtein "" "")))
+      (is (= 0 (levenshtein "" "" 10 10 10)))
+      ;; 1 character
+      (is (= 1 (levenshtein "1" "2")))
+      ;; 2 characters swapped
+      (is (= 2 (levenshtein "12" "21")))
+      ;; inexpensive deletion
+      (is (= 2 (levenshtein "2121" "11" 2 1 1)))
+      ;; expensive deletion
+      (is (= 10 (levenshtein "2121" "11" 2 1 5)))
+      ;; inexpensive insertion
+      (is (= 2 (levenshtein "11" "2121")))
+      ;; expensive insertion
+      (is (= 10 (levenshtein "11" "2121" 5 1 1)))
+      ;; inexpensive replacement
+      (is (= 3 (levenshtein "111" "121" 2 3 2)))
+      ;; very expensive replacement
+      (is (= 4 (levenshtein "111" "121" 2 9 2))))
+    ;; test cases from https://github.com/php/php-src/blob/master/ext/standard/tests/strings/levenshtein_error_conditions.phpt
+    (testing "PHP Test Cases"
+      ;; levenshtein no longer has a maximum string length limit
+      (is (= 254 (levenshtein "AbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsu" "A")))
+      (is (= 255 (levenshtein "AbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuv" "A")))
+      (is (= 254 (levenshtein "A" "AbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsu")))
+      (is (= 255 (levenshtein "A" "AbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuv"))))
+    ;; test cases from https://github.com/php/php-src/blob/master/ext/standard/tests/strings/levenshtein_bug_16473.phpt
+    (testing "PHP Bug #16473 Test Cases"
+      (is (= 2 (levenshtein "a" "bc")))
+      (is (= 2 (levenshtein "xa" "xbc")))
+      (is (= 2 (levenshtein "xax" "xbcx")))
+      (is (= 2 (levenshtein "ax" "bcx"))))
+    ;; test cases from https://github.com/php/php-src/blob/master/ext/standard/tests/strings/levenshtein_bug_6562.phpt
+    (testing "PHP Bug #6562 Test Cases"
+      (is (= 1 (levenshtein "debug" "debugg")))
+      (is (= 1 (levenshtein "ddebug" "debug")))
+      (is (= 2 (levenshtein "debbbug" "debug")))
+      (is (= 1 (levenshtein "debugging" "debuging"))))
+    ;; test cases from https://github.com/php/php-src/blob/master/ext/standard/tests/strings/levenshtein_bug_7368.phpt
+    (testing "PHP Bug #7368 Test Cases"
+      (is (= 2 (levenshtein "13458" "12345")))
+      (is (= 2 (levenshtein "1345" "1234"))))))


### PR DESCRIPTION
`clojure.core/doseq` needs to be ignored because it's a macro that will expand to a recursive call which contains a branch and it's just impossible to evaluate every possible branch in a recursion.