### PR TITLE
add str_rot13 implementation

### DIFF
--- a/csharp/Pehape/String/StrRot13.cs
+++ b/csharp/Pehape/String/StrRot13.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Performs the ROT13 encoding on the string argument and returns the resulting string.
+		/// </summary>
+		/// <remarks>
+		/// The ROT13 encoding simply shifts every letter by 13 places in the alphabet while 
+		/// leaving non-alpha characters untouched. Encoding and decoding are done by the same 
+		/// function, passing an encoded string as argument will return the original version.
+		/// </remarks>
+		/// <param name="str">The input string.</param>
+		/// <returns>Returns the ROT13 version of the given string.</returns>
+		public static string StrRot13(string str) {
+			if (str is null) throw new ArgumentNullException(nameof(str));
+
+			var buffer = new StringBuilder();
+			foreach (char ch in str) {
+				buffer.Append((char)(ch switch {
+					>= 'a' and <= 'z' => ch > 'm' ? ch - 13 : ch + 13,
+					>= 'A' and <= 'Z' => ch > 'M' ? ch - 13 : ch + 13,
+					_ => ch
+				}));
+			}
+			return buffer.ToString();
+		}
+	}
+}

--- a/csharp/Tests/String/StrRot13Tests.cs
+++ b/csharp/Tests/String/StrRot13Tests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using Pehape;
+using System;
+using Xunit;
+
+namespace Tests.String {
+	public class StrRot13Tests {
+		// Source: https://github.com/php/php-src/blob/master/ext/standard/tests/strings/str_rot13_basic.phpt
+
+		// Basic test
+		[InlineData("Hello, World!", "Uryyb, Jbeyq!")]
+		[InlineData("str_rot13() tests starting", "fge_ebg13() grfgf fgnegvat")]
+		[InlineData("abcdefghijklmnopqrstuvwxyz", "nopqrstuvwxyzabcdefghijklm")]
+		[InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "NOPQRSTUVWXYZABCDEFGHIJKLM")]
+
+		// Ensure numeric characters are left untouched
+		[InlineData("0123456789", "0123456789")]
+
+		// Ensure non-alphabetic characters are left untouched";
+		[InlineData("!%^&*()_-+={}[]:;@~#<,>.?", "!%^&*()_-+={}[]:;@~#<,>.?")]
+
+		// Additional tests
+
+		// Empty string left untouched
+		[InlineData("", "")]
+
+		// Whitespaces should left untouched
+		[InlineData("    \r\n", "    \r\n")]
+
+		// Non latin alphabet
+		[InlineData("地獄、お元気ですか XD", "地獄、お元気ですか KQ")]
+		[InlineData("drs الجحيم كيف حالك drs", "qef الجحيم كيف حالك qef")]
+
+		[Theory]
+		public void ReturnRot13ShiftedString(string inputString, string expectedOutput) {
+			PHP.StrRot13(inputString).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null)]
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string str) {
+			new Action(() => PHP.StrRot13(str)).Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}


### PR DESCRIPTION
Add [str_rot13](https://www.php.net/manual/en/function.str-rot13.php) implementation. 

**Question**: 
PHP's original method name is `str_rot13`. Should we follow their style? Or just use C# naming convention?

Blatant self promotion - you can test php str_rot13 [here](https://php.gopud.net/index.php?fn=str_rot13&ts=1647839116&string=drs+%D8%A7%D9%84%D8%AC%D8%AD%D9%8A%D9%85+%D9%83%D9%8A%D9%81+%D8%AD%D8%A7%D9%84%D9%83+drs).