### PR TITLE
feat: add implementation of Md5, StrContains, StrRepeat, Strrev, and Substr

### DIFF
--- a/csharp/Pehape/String/Md5.cs
+++ b/csharp/Pehape/String/Md5.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Calculate the md5 hash of a string.
+		/// </summary>
+		/// <remarks>In PHP's version, there are a second parameter which whould change
+		/// the function output format to binary.</remarks>
+		/// <param name="str">The string.</param>
+		/// <returns>Returns the hash as a 32-character lowercases hexadecimal number.</returns>
+		[SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "PHP's md5 output are in lowercases")]
+		public static string Md5(string str) {
+			// In php, md5 of null are calculated as empty string, we decide to avoid that behaviour in this version
+			if (str is null) throw new ArgumentNullException(nameof(str));
+			
+			byte[] hashBytes = Md5Binary(str);
+			return Convert.ToHexString(hashBytes).ToLowerInvariant();
+		}
+
+		/// <summary>
+		/// Calculate the md5 hash of a string.
+		/// </summary>
+		/// <param name="str"></param>
+		/// <returns>Returns the hash as a 32 byte array</returns>
+		[SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms", Justification = "PHP does have MD5 function")]
+		public static byte[] Md5Binary(string str) {
+			if (str is null) throw new ArgumentNullException(nameof(str));
+
+			using var md5 = MD5.Create();
+			return md5.ComputeHash(Encoding.UTF8.GetBytes(str));
+		}
+	}
+}

--- a/csharp/Pehape/String/StrContains.cs
+++ b/csharp/Pehape/String/StrContains.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Determine if a string contains a given substring.
+		/// </summary>
+		/// <remarks>
+		/// This function only exist starting from PHP version 8.
+		/// </remarks>
+		/// <param name="haystack">The string to search in.</param>
+		/// <param name="needle">The substring to search for in the haystack.</param>
+		/// <returns>Returns true if needle is in haystack, false otherwise.</returns>
+		public static bool StrContains(string haystack, string needle) {
+			if (haystack is null) throw new ArgumentNullException(nameof(haystack));
+			if (needle is null) throw new ArgumentNullException(nameof(needle));
+
+			return haystack.Contains(needle, StringComparison.InvariantCulture);
+		}
+	}
+}

--- a/csharp/Pehape/String/StrRepeat.cs
+++ b/csharp/Pehape/String/StrRepeat.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Repeat a string.
+		/// </summary>
+		/// <remarks>
+		/// Times has to be greater than or equal to 0. If the times is set to 0,
+		/// the function will return an empty string.
+		/// </remarks>
+		/// <param name="str">The string to be repeated.</param>
+		/// <param name="times">Number of time the string string should be repeated.</param>
+		/// <returns>Returns the repeated string.</returns>
+		public static string StrRepeat(string str, int times) {
+			if (str is null) throw new ArgumentNullException(nameof(str));
+			// when	`times` are negative, php would return an empty string but print a warning
+			if (times < 0) throw new ArgumentOutOfRangeException(nameof(times), "parameter times cannot be negative");
+
+			if (times == 0) return string.Empty;
+			return string.Concat(Enumerable.Repeat(str, times));
+		}
+	}
+}

--- a/csharp/Pehape/String/Strrev.cs
+++ b/csharp/Pehape/String/Strrev.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Reverse a string.
+		/// </summary>
+		/// <param name="str">The string to be reversed.</param>
+		/// <returns>Returns the reversed string.</returns>
+		public static string Strrev(string str) {
+			if (str is null) throw new ArgumentNullException(nameof(str));
+
+			string[] graphemeClusters = GetGraphemeClusters(str).ToArray();
+			Array.Reverse(graphemeClusters);
+			return string.Join("", graphemeClusters);
+		}
+
+		private static IEnumerable<string> GetGraphemeClusters(string str) {
+			/*
+		  	 this implementation  support reversing Grapheme Clusters correctly which is taken from
+			   https://stackoverflow.com/questions/228038/best-way-to-reverse-a-string/15111719#15111719
+			   more info: 
+			    - https://unicode.org/reports/tr29/, 
+			    - https://en.wikipedia.org/wiki/Graphem
+				  - https://docs.rs/unicode-reverse/latest/unicode_reverse/
+			*/
+			TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(str);
+			while (enumerator.MoveNext()) {
+				yield return (string)enumerator.Current;
+			}
+		}
+	}
+}

--- a/csharp/Pehape/String/Substr.cs
+++ b/csharp/Pehape/String/Substr.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Pehape {
+	public static partial class PHP {
+		/// <summary>
+		/// Returns the portion of string specified by the offset and length parameters.
+		/// </summary>
+		/// <remarks>
+		/// - If offset is negative, the returned string will start at the offset position from the end of string.
+		/// - If length is given and is negative, then that many characters will be omitted from the end of string.
+		/// </remarks>
+		/// <param name="str">The input string.</param>
+		/// <param name="offset">Starting position.</param>
+		/// <param name="length">(optional) length of the returned substring.</param>
+		/// <returns>Extracted part of the input string, or an empty string.</returns>
+		public static string Substr(string str, int offset, int? length = null) {
+			if (str is null) throw new ArgumentNullException(nameof(str));
+			if (offset > str.Length) return string.Empty;
+			if (offset < 0 && Math.Abs(offset) > str.Length) return str;
+			if (length is 0) return string.Empty;
+
+			// offset is negative, we cut it from the right side (like python index)
+			int startIndex = offset;
+			if (offset < 0)
+				startIndex = str.Length + offset;
+
+			if (length == null)
+				return str[startIndex..];
+
+			/* positive length case */
+
+			int cutOffLength = length.Value;
+			if (cutOffLength >= 0)
+				return str.Substring(startIndex, cutOffLength);
+
+			/* when length is negative, chop off the substring starting from right */
+
+			string temp = str[startIndex..];
+			// too much character to omit
+			if (temp.Length + cutOffLength < 0)
+				return string.Empty;
+
+			return temp.Remove(temp.Length + cutOffLength);
+		}
+	}
+}

--- a/csharp/Tests/String/Md5Test.cs
+++ b/csharp/Tests/String/Md5Test.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using FluentAssertions;
+using Pehape;
+using Xunit;
+
+namespace Tests.String {
+	public class Md5Test {
+		[InlineData("Hello World", "b10a8db164e0754105b7a99be72e3fe5")]
+		[InlineData("Hello World!", "ed076287532e86365e841e92bfc50d8c")]
+
+		[InlineData("12345678901234567890123456789012345678901234567890123456789012345678901234567890", "57edf4a22be3c955ac49da2e2107b67a")]
+		[InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", "d174ab98d277d9f5a5611c2c9f419d9f")]
+
+		[InlineData("", "d41d8cd98f00b204e9800998ecf8427e")]
+
+		[InlineData("Iñtërnâtiônàlizætiøn", "e5e628206e73b1ae69b37fc69762a1e1")]
+		[InlineData("اختبار md 5 آجا", "af16b693491fc21bc80f157021c3bb71")]
+
+		[Theory]
+		public void ReturnValidMd5Hash(string inputString, string expectedOutput) {
+			PHP.Md5(inputString).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null)]
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string inputString) {
+			new Action(() => PHP.Md5(inputString)).Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}

--- a/csharp/Tests/String/StrContainsTest.cs
+++ b/csharp/Tests/String/StrContainsTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using FluentAssertions;
+using Pehape;
+using Xunit;
+
+namespace Tests.String
+{
+	public class StrContainsTest {
+		[InlineData("hello world", "hello", true)]
+		[InlineData("hello world", "hello!", false)]
+		[InlineData("hellO world", "hello", false)]
+		[InlineData("hello world", "", true)]
+
+		// https://github.com/php/php-src/blob/master/ext/standard/tests/strings/str_contains.phpt
+
+		[InlineData("test string", "t s", true)]
+		[InlineData("tEst", "test", false)]
+		[InlineData("", "", true)]
+		[InlineData("", "a", false)]
+		[InlineData("a      a", "   ", true)]
+
+		[InlineData("\\\\a", "\\a", true)]
+		[InlineData("例の単語", "の単", true)]
+		[InlineData("アネバンゲット", "の単", false)]
+
+		[Theory]
+		public void CheckIfHaystackContainNeedle(string stringToCheck, string stringToLookFor, bool expectedOutput) {
+			PHP.StrContains(stringToCheck, stringToLookFor).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null, "b")]
+		[InlineData(typeof(ArgumentNullException), "a", null)]
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string haystack, string needle) {
+			new Action(() => PHP.StrContains(haystack, needle)).Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}

--- a/csharp/Tests/String/StrRepeatTest.cs
+++ b/csharp/Tests/String/StrRepeatTest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using FluentAssertions;
+using Pehape;
+using Xunit;
+
+namespace Tests.String
+{
+	public class StrRepeatTest {
+		// https://github.com/php/php-src/blob/master/ext/standard/tests/strings/str_repeat.phpt
+		[InlineData("ha", 2,"haha")]
+		[InlineData("foo", 4,"foofoofoofoo")]
+		[InlineData("foo", 0, "")]
+		[InlineData("%0", 3, "%0%0%0")]
+		[InlineData("\0", 2, "\0\0")]
+		[InlineData("\n\t", 2, "\n\t\n\t")]
+		[InlineData("1.23", 3, "1.231.231.23")]
+		[InlineData("", 0, "")]
+		[InlineData("", 1, "")]
+		[InlineData("", 4, "")]
+		[InlineData(" ", 0, "")]
+		[InlineData(" ", 4, "    ")]
+		[InlineData(" _ ", 3, " _  _  _ ")]
+		[InlineData("終わり", 3, "終わり終わり終わり")]
+
+		[Theory]
+		public void ReturnReversedString(string stringToRepeat, int numberOfRepetition, string expectedOutput) {
+			PHP.StrRepeat(stringToRepeat, numberOfRepetition).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null, 3)]
+		[InlineData(typeof(ArgumentOutOfRangeException), "oke", -1)]
+
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string stringToRepeat, int times) {
+			new Action(() => PHP.StrRepeat(stringToRepeat, times))
+				.Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}

--- a/csharp/Tests/String/StrrevTest.cs
+++ b/csharp/Tests/String/StrrevTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FluentAssertions;
+using Pehape;
+using Xunit;
+
+namespace Tests.String
+{
+	public class StrrevTest {
+		[InlineData("hello", "olleh")]
+		[InlineData("", "")]
+		[InlineData("Hello", "olleH")]
+		[InlineData(" a b c d ", " d c b a ")]
+		[InlineData("   ", "   ")]
+		[InlineData("123454321", "123454321")]
+		[InlineData("☆❤world", "dlrow❤☆")]
+		[InlineData("トマト", "トマト")]
+		[InlineData("!!!", "!!!")]
+
+		// https://stackoverflow.com/questions/228038/best-way-to-reverse-a-string/15111719#15111719
+		[InlineData("Les Mise\u0301rables", "selbare\u0301siM seL")]
+
+		// https://mathiasbynens.be/notes/javascript-unicode
+		[InlineData("ma\u006E\u0303ana", "ana\u006E\u0303am")]
+
+		[Theory]
+		public void ReturnReversedString(string stringToCheck, string expectedOutput) {
+			PHP.Strrev(stringToCheck).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null)]
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string str) {
+			new Action(() => PHP.Strrev(str)).Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}

--- a/csharp/Tests/String/SubstrTests.cs
+++ b/csharp/Tests/String/SubstrTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using Pehape;
+using System;
+using Xunit;
+
+namespace Tests.String {
+	public class SubstrTest {
+
+		// basic offset test
+		[InlineData("abcdef", 2, "cdef")]
+		[InlineData("abcdef", 0, "abcdef")]
+
+		// negative offset
+		[InlineData("abcdef", -1, "f")]
+		[InlineData("abcdef", -2, "ef")]
+		[InlineData("abcdef", -6, "abcdef")]
+
+		// If string is less than offset characters long, an empty string will be returned.
+		[InlineData("abcdef", 10, "")]
+
+		// however.. if it's negative length, it will return the original string
+		[InlineData("abcdef", -7, "abcdef")]
+		[InlineData("abcdef", -10, "abcdef")]
+
+		// null characters..
+		[InlineData("abc\x0xy\x0z", 2, "c\x0xy\x0z")]
+		[InlineData("Iñtërnâtiônàlizætiøn", 3, "ërnâtiônàlizætiøn")]
+
+		// empty case
+		[InlineData("", 0, "")]
+		[InlineData("", 1, "")]
+
+		[Theory]
+		public void ReturnSubstringFromGivenOffsetPosition(string inputString, int offset, string expectedOutput) {
+			PHP.Substr(inputString, offset).Should().Be(expectedOutput);
+		}
+
+		// basic length test
+		[InlineData("abcdef", 0, 3, "abc")]
+
+		// If length is given and is negative, then that many characters will be omitted from the end of string
+		[InlineData("abcdef", 0, -2, "abcd")]
+		[InlineData("abcdef", 3, -1, "de")]
+		[InlineData("abcdef", 3, -10, "")]
+
+		// both length and offset is negative
+		[InlineData("abcdef", -3, -1, "de")]
+		[InlineData("abcdef", -3, -2, "d")]
+		[InlineData("abcdef", -3, -3, "")]
+
+
+		// taken from https://github.com/php/php-src/blob/master/ext/standard/tests/strings/substr.phpt
+		// Testing for variations of start and length to point to same element
+		[InlineData("abcde" , 2, -2, "c")]
+		[InlineData("abcde", -3, -2, "c")]
+
+		// Testing for start > truncation
+		[InlineData("abcdef", 4, -4, "")]
+
+		// empty case
+		[InlineData("", 0, 0, "")]
+
+		[Theory]
+		public void ReturnSubstringWithOffsetAndLength(string inputString, int offset, int length, string expectedOutput) {
+			PHP.Substr(inputString, offset, length).Should().Be(expectedOutput);
+		}
+
+		[InlineData(typeof(ArgumentNullException), null, 0, null)]
+		[InlineData(typeof(ArgumentNullException), null, 0, 2)]
+		[InlineData(typeof(ArgumentNullException), null, 5, 10)]
+		[Theory]
+		public void ThrowsExceptionWhenInvalidArgumentSupplied(Type exceptionType, string inputString, int offset, int? length) {
+			new Action(() => PHP.Substr(inputString, offset, length)).Should().Throw<Exception>().Which.Should().BeOfType(exceptionType);
+		}
+	}
+}


### PR DESCRIPTION
List of implemented functions:

- [md5](https://www.php.net/manual/en/function.md5.php)
- [str_contains](https://www.php.net/manual/en/function.str-contains.php)
- [str_repeat](https://www.php.net/manual/en/function.str-repeat.php)
- [strrev](https://www.php.net/manual/en/function.strrev.php)
- [substr](https://www.php.net/manual/en/function.substr.php)

Notes: I decide to alter the method signature for `md5()`. In original PHP function, there is a second argument (`binary`) which if set to `true` will change the function return type to binary array. In this implementation, I remove those argument and split the functionality into a separate function (`Md5Binary`). What do you think?