### PR TITLE
feat: add bin_2_hex and hex_2_bin

### DIFF
--- a/rust/src/string/bin_2_hex.rs
+++ b/rust/src/string/bin_2_hex.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, PartialEq)]
+pub enum Bin2HexError {
+    EmptyStr,
+    NonASCII
+}
+
+// The bin_2_hex function converts a string of ASCII characters to their hexadecimal representation.
+// Parameter:
+// - s => string that is to be converted
+// 
+// Return:
+// - A string of their hexadecimal representation
+pub fn bin_2_hex(s: &str) -> Result<String, Bin2HexError> {
+    if s.is_empty() {
+        return  Err(Bin2HexError::EmptyStr);
+    }
+
+    let mut result: String = String::new();
+    for c in s.as_bytes() {
+        if !c.is_ascii() {
+            return Err(Bin2HexError::NonASCII);
+        }
+
+        result.push_str(&format!("{:x}", c))
+    }
+
+    return Ok(result);
+}

--- a/rust/src/string/hex_2_bin.rs
+++ b/rust/src/string/hex_2_bin.rs
@@ -1,0 +1,31 @@
+#[derive(Debug, PartialEq)]
+pub enum Hex2BinError {
+    EmptyInput,
+    InvalidLength,
+    InvalidHexCharacter(std::num::ParseIntError),
+}
+
+const HEX_CHAR_LEN: usize = 2;
+const HEX_BASE: u32 = 16;
+
+// The hex_2_bin function converts a string of hexadecimal to the ascii characters.
+// Parameter:
+// - s => hexadecimal that is to be converted
+// 
+// Return:
+// - a string of ASCII characters corresponding to the input hexadecimal
+pub fn hex_2_bin(hex: &str) -> Result<String, Hex2BinError> {
+    match hex.len() {
+        0 => Err(Hex2BinError::EmptyInput),
+        _ if hex.len() % 2 != 0 => Err(Hex2BinError::InvalidLength),
+        _ => {
+            let mut result = String::new();
+            for i in (0..hex.len()).step_by(HEX_CHAR_LEN) {
+                let byte_str = &hex[i..i + HEX_CHAR_LEN];
+                let byte = u8::from_str_radix(byte_str, HEX_BASE).map_err(Hex2BinError::InvalidHexCharacter)?;
+                result.push(byte as char);
+            }
+            Ok(result)
+        }
+    }
+}

--- a/rust/tests/string_test/bin_2_hex_test.rs
+++ b/rust/tests/string_test/bin_2_hex_test.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+mod tests {
+    use pehape_rs::bin_2_hex;
+
+    #[test]
+    fn test_bin_2_hex() {
+        assert_eq!(bin_2_hex("Hello World!!"), Ok(String::from("48656c6c6f20576f726c642121")));
+        assert_eq!(bin_2_hex("hacktoberfest1234!@#"), Ok(String::from("6861636b746f6265726665737431323334214023")));
+    }
+}

--- a/rust/tests/string_test/hex_2_bin_test.rs
+++ b/rust/tests/string_test/hex_2_bin_test.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+mod tests {
+    use pehape_rs::hex_2_bin;
+
+    #[test]
+    fn test_hex_2_bin() {
+        assert_eq!(hex_2_bin("48656c6c6f20576f726c642121"), Ok(String::from("Hello World!!")));
+        assert_eq!(hex_2_bin("6861636b746f6265726665737431323334214023"), Ok(String::from("hacktoberfest1234!@#")));
+    }
+}


### PR DESCRIPTION
<!-- Please fill these: -->

- Programming langugage: Rust
- Function(s) that I'm implementing: `bin_2_hex` and `hex_2_bin`
- Issue number: #25 bin2hex

- [x] I have created unit tests to support my implementation
- [x] I have created in-code documentation (or docstring) to document my code

<!-- If you have any other notes, please put it here -->
<!-- Thank you for your contribution! -->